### PR TITLE
Convert YASH-Traffix-POC/Migrate_pipeline to GitHub Actions

### DIFF
--- a/.github/workflows/migrate_pipeline.yml
+++ b/.github/workflows/migrate_pipeline.yml
@@ -1,0 +1,24 @@
+name: YASH-Traffix-POC/Migrate_pipeline
+on:
+  push:
+    branches:
+    - none
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4.1.0
+    # The dotnet CLI does not accept glob patterns. Consider using a solution file to act on multiple projects at once.
+    - name: dotnet restore
+      run: dotnet restore **/*.csproj
+    # The dotnet CLI does not accept glob patterns. Consider using a solution file to act on multiple projects at once.
+    - name: dotnet build
+      run: dotnet build **/*.csproj --configuration ${{ env.BuildConfiguration }}
+    - name: dotnet publish
+      run: dotnet publish --configuration ${{ env.BuildConfiguration }} --output ${{ runner.temp }}
+    - name: 'Publish Artifact: drop'
+      uses: actions/upload-artifact@v4.1.0
+      with:
+        name: drop--${{ github.run_id }}-${{ github.run_number }}
+        path: "${{ runner.temp }}"


### PR DESCRIPTION
Pipeline migrated from [Azure DevOps](https://dev.azure.com/YASHTech-Traffix/YASH-Traffix-POC/_build?definitionId=66) :tada: